### PR TITLE
Enable workspace configuration calls

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -23,4 +23,4 @@ jobs:
         with:
           workspace: w4U_SVbTOimwP0txQVsPBew
       - name: list application
-        run: mabl applications list -w 4U_SVbTOimwP0txQVsPBew-w
+        run: mabl applications list

--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -21,6 +21,6 @@ jobs:
         env:
           MABL_API_KEY: ${{ secrets.MABL_API_KEY }}
         with:
-          workspace: w4U_SVbTOimwP0txQVsPBew-w
+          workspace: 4U_SVbTOimwP0txQVsPBew-w
       - name: list application
         run: mabl applications list

--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -8,9 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
       - name: Install dependencies
         run: npm install
       - name: Compile typescript

--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
       - name: Install dependencies
         run: npm install
       - name: Compile typescript

--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -20,5 +20,7 @@ jobs:
         uses: ./
         env:
           MABL_API_KEY: ${{ secrets.MABL_API_KEY }}
+        with:
+          workspace: w4U_SVbTOimwP0txQVsPBew
       - name: list application
         run: mabl applications list -w 4U_SVbTOimwP0txQVsPBew-w

--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -21,6 +21,6 @@ jobs:
         env:
           MABL_API_KEY: ${{ secrets.MABL_API_KEY }}
         with:
-          workspace: w4U_SVbTOimwP0txQVsPBew
+          workspace: w4U_SVbTOimwP0txQVsPBew-w
       - name: list application
         run: mabl applications list

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ installs the cli and configures it with an API key, if one is provided. Note
 that API keys should be stored as secrets.
 
 This action requires a version of node be installed as part of your workflow.
-The mabl-cli will be installed into that node runtime.  
+The [mabl-cli](https://www.npmjs.com/package/@mablhq/mabl-cli) will be installed into that node runtime.  
 See below for an example of how to install node.
 
 Note that this action and the mabl CLI are in BETA. Some interfaces may change

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ installs the cli and configures it with an API key, if one is provided. Note
 that API keys should be stored as secrets.
 
 This action requires a version of node be installed as part of your workflow.
+The mabl-cli will be installed into that node runtime.  
 See below for an example of how to install node.
 
 Note that this action and the mabl CLI are in BETA. Some interfaces may change
-without prior notice,
+without prior notice.
 
 ## Inputs
 
@@ -25,6 +26,11 @@ without prior notice,
   The MABL_API_KEY should be stored as a repositor secret and pased as in the
   example below. Never store your MABL_API_KEY in plain test in your action.
 
+## Requirements
+
+- Requires node to be installed as a prior step. This is most easily done with
+  the 'actions/setup-node@v1' command
+
 ## Example workflow:
 
 ```
@@ -37,6 +43,9 @@ jobs:
     name: mabl Test
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
       - uses: mablhq/setup-mabl-cli@v1.0
         with:
           version: 0.1.2-beta

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.7",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/node/-/node-12.12.7.tgz",
-      "integrity": "sha1-AeTqck2eO9UNkMEf1ZgLoxfY+hE=",
+      "version": "12.12.24",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/node/-/node-12.12.24.tgz",
+      "integrity": "sha1-1GBq/Yz2xgkDa4VDYDZ9Gyx4kx8=",
       "dev": true
     },
     "@types/q": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.12.7",
+    "@types/node": "^12.12.24",
     "@types/q": "^1.5.2",
     "@types/request-promise-native": "^1.0.16"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ async function run() {
   await authenticateWithApiKey(apiKey, nodePath);
 
   if (workspace) {
-    await configureWorkspace(workspace);
+    await configureWorkspace(workspace, nodePath);
   }
 }
 
@@ -37,9 +37,13 @@ async function installCli(version: string, nodePath: string) {
   await exec.exec(installCommand, [], options);
 }
 
-async function configureWorkspace(workspace: string) {
-  await exec.exec(`mabl config set workspace ${workspace}`);
-  await exec.exec(`mabl config set workspace ${workspace}`);
+async function configureWorkspace(workspace: string, nodePath: string) {
+  const options = {
+    cwd: nodePath,
+  };
+
+  await exec.exec(`mabl config set workspace ${workspace}`, [], options);
+  await exec.exec(`mabl config list`, [], options);
 }
 
 async function findNode() {
@@ -63,6 +67,8 @@ async function authenticateWithApiKey(apiKey: string, nodePath: string) {
 
   const command: string = `mabl auth activate-key ${apiKey}`;
   await exec.exec(command, [], options);
+
+  await exec.exec('mabl auth info', [], options);
 }
 
 run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,6 @@ async function configureWorkspace(workspace: string) {
 
 async function findNode() {
   const allNodeVersions = await toolCache.findAllVersions('node');
-  core.info(`all versions, ${allNodeVersions}`);
   if (!allNodeVersions || !allNodeVersions[0]) {
     core.setFailed(
       'No node version installed.  Please add a "actions/setup-node" step to your workflow or install a node version some other way.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,9 @@ async function run() {
     return;
   }
 
-  await authenticateWithApiKey(apiKey, nodePath);
+  if (!(await authenticateWithApiKey(apiKey, nodePath))) {
+    return;
+  }
 
   if (workspace) {
     await configureWorkspace(workspace, nodePath);
@@ -37,7 +39,10 @@ async function installCli(version: string, nodePath: string) {
   await exec.exec(installCommand, [], options);
 }
 
-async function configureWorkspace(workspace: string, nodePath: string) {
+async function configureWorkspace(
+  workspace: string,
+  nodePath: string,
+): Promise<boolean> {
   const options = {
     cwd: nodePath,
   };
@@ -48,8 +53,12 @@ async function configureWorkspace(workspace: string, nodePath: string) {
     core.setFailed(
       `Failed while trying to configure workspace with error ${err}`,
     );
+
+    return false;
   }
   await exec.exec(`mabl config list`, [], options);
+
+  return true;
 }
 
 async function findNode() {
@@ -66,7 +75,10 @@ async function findNode() {
   return toolCache.find('node', nodeVersion);
 }
 
-async function authenticateWithApiKey(apiKey: string, nodePath: string) {
+async function authenticateWithApiKey(
+  apiKey: string,
+  nodePath: string,
+): Promise<boolean> {
   const options = {
     cwd: nodePath,
   };
@@ -76,9 +88,13 @@ async function authenticateWithApiKey(apiKey: string, nodePath: string) {
     await exec.exec(command, [], options);
   } catch (err) {
     core.setFailed(`Failed while trying to activate api key with error ${err}`);
+
+    return false;
   }
 
   await exec.exec('mabl auth info', [], options);
+
+  return true;
 }
 
 run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ async function configureWorkspace(
 
 async function findNode() {
   const allNodeVersions = await toolCache.findAllVersions('node');
-  if (!allNodeVersions || !allNodeVersions[0]) {
+  if (!(allNodeVersions && allNodeVersions[0])) {
     core.setFailed(
       'No node version installed.  Please add a "actions/setup-node" step to your workflow or install a node version some other way.',
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,8 +42,8 @@ async function configureWorkspace(workspace: string) {
   await exec.exec(`mabl config set workspace ${workspace}`);
 }
 
-function findNode() {
-  const allNodeVersions = toolCache.findAllVersions('node');
+async function findNode() {
+  const allNodeVersions = await toolCache.findAllVersions('node');
   core.info(`all versions, ${allNodeVersions}`);
   if (!allNodeVersions) {
     core.setFailed(

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ async function run() {
     return;
   }
 
-  installCli(version, nodePath);
+  await installCli(version, nodePath);
 
   if (!apiKey) {
     core.setFailed('Please specify api key as an environment variable');

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ async function configureWorkspace(workspace: string) {
 
 function findNode() {
   const allNodeVersions = toolCache.findAllVersions('node');
+  core.info(`all versions, ${allNodeVersions}`);
   if (!allNodeVersions) {
     core.setFailed(
       'No node version installed.  Please add a "actions/setup-node" step to your workflow or install a node version some other way.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,23 +7,23 @@ async function run() {
   const workspace = core.getInput('workspace', {required: false});
   const apiKey: string | undefined = process.env.MABL_API_KEY;
 
-  const nodePath = findNode();
+  const nodePath = await findNode();
 
   if (!nodePath) {
     return;
   }
 
-  await installCli(version, nodePath);
+  installCli(version, nodePath);
 
   if (!apiKey) {
     core.setFailed('Please specify api key as an environment variable');
     return;
   }
 
-  authenticateWithApiKey(apiKey, nodePath);
+  await authenticateWithApiKey(apiKey, nodePath);
 
   if (workspace) {
-    configureWorkspace(workspace);
+    await configureWorkspace(workspace);
   }
 }
 
@@ -37,8 +37,9 @@ async function installCli(version: string, nodePath: string) {
   await exec.exec(installCommand, [], options);
 }
 
-function configureWorkspace(workspace: string) {
-  exec.exec(`mabl config set workspace ${workspace} && mabl config list`);
+async function configureWorkspace(workspace: string) {
+  await exec.exec(`mabl config set workspace ${workspace}`);
+  await exec.exec(`mabl config set workspace ${workspace}`);
 }
 
 function findNode() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ async function configureWorkspace(workspace: string) {
 async function findNode() {
   const allNodeVersions = await toolCache.findAllVersions('node');
   core.info(`all versions, ${allNodeVersions}`);
-  if (!allNodeVersions) {
+  if (!allNodeVersions || !allNodeVersions[0]) {
     core.setFailed(
       'No node version installed.  Please add a "actions/setup-node" step to your workflow or install a node version some other way.',
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ async function authenticateWithApiKey(
   try {
     await exec.exec(command, [], options);
   } catch (err) {
-    core.setFailed(`Failed while trying to activate api key with error ${err}`);
+    core.setFailed(`Failed while trying to activate API key with error ${err}`);
 
     return false;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as toolCache from '@actions/tool-cache';
 
 async function run() {
   const version = core.getInput('version', {required: false});
-  // const workspace = core.getInput('workspace', {required: false});
+  const workspace = core.getInput('workspace', {required: false});
   const apiKey: string | undefined = process.env.MABL_API_KEY;
 
   const nodePath = findNode();
@@ -22,9 +22,9 @@ async function run() {
 
   authenticateWithApiKey(apiKey, nodePath);
 
-  // if (workspace) {
-  // configureWorkspace(workspace);
-  // }
+  if (workspace) {
+    configureWorkspace(workspace);
+  }
 }
 
 async function installCli(version: string, nodePath: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,13 @@ async function configureWorkspace(workspace: string, nodePath: string) {
     cwd: nodePath,
   };
 
-  await exec.exec(`mabl config set workspace ${workspace}`, [], options);
+  try {
+    await exec.exec(`mabl config set workspace ${workspace}`, [], options);
+  } catch (err) {
+    core.setFailed(
+      `Failed while trying to configure workspace with error ${err}`,
+    );
+  }
   await exec.exec(`mabl config list`, [], options);
 }
 
@@ -66,7 +72,11 @@ async function authenticateWithApiKey(apiKey: string, nodePath: string) {
   };
 
   const command: string = `mabl auth activate-key ${apiKey}`;
-  await exec.exec(command, [], options);
+  try {
+    await exec.exec(command, [], options);
+  } catch (err) {
+    core.setFailed(`Failed while trying to activate api key with error ${err}`);
+  }
 
   await exec.exec('mabl auth info', [], options);
 }


### PR DESCRIPTION
Number of improvemnets here:

1)  Appropriately wait for all steps to complete without moving on to the next
2)  Re-enable workspace configuration
3)  Much improved error handling when installation or configuration fails
4)  Updated example to include node installation step

Github actions toolkit docs here:  https://github.com/actions/toolkit/tree/master/packages