### PR TITLE
[MABL-5313] Fix spec typo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: (optional) The version of the mabl CLI to install
     required: false
   workspace:
+    description: (optional) DEPRECATED use workspace-id
+    required: false
+  workspace-id:
     description: (optional) The id of the workspace to configure as default for the CLI
     required: false
 runs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-mabl-cli",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-mabl-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "mabl GitHub action to setup mabl CLI",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Address PR #13 , by fixing the source of the issue in the spec.

This should remove warnings when using `workflow` vs `workflow-id`